### PR TITLE
Make Travis faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 # - "Compile & Test": this actually needs Rust and compiles everything
 matrix:
   fast_finish: true
+  allow_failures:
+    - name: "Compile & Test WASM"
   include:
     - name: "Check style"
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,23 @@ matrix:
     - name: "Check style"
       language: generic
       script: ./ci/check-basic-style.sh
-    - name: "Compile & Test"
+    - name: "Compile & Test Desktop"
       language: rust
       rust: nightly
       env:
         - RUSTFLAGS="--deny warnings"
+      before_script:
+        - sudo apt-get install xorg-dev
+      script:
+        - cargo build --verbose -p mahboi -p mahboi-desktop
+        - cargo test --verbose -p mahboi -p mahboi-desktop
       # speeds up travis build
       cache: cargo
+    - name: "Compile & Test WASM"
+      language: rust
+      rust: nightly
+      env:
+        - RUSTFLAGS="--deny warnings"
       before_script:
         - sudo apt-get install xorg-dev nodejs npm
         - hash cargo-script 2>/dev/null || cargo install -f cargo-script
@@ -22,6 +32,8 @@ matrix:
         - npm config set strict-ssl false # because some random NPM error... uhg
         - sudo npm install -g typescript
       script:
-        - cargo build --verbose
-        - cargo test --verbose
+        - cargo build --verbose -p mahboi -p mahboi-web
+        - cargo test --verbose  -p mahboi -p mahboi-web
         - cd web && ./build-all.rs
+      # speeds up travis build
+      cache: cargo

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,3 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 derive_more = "0.11.0"
-
-[build-dependencies]
-failure = "0.1.2"
-reqwest = "0.8"

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,19 +1,21 @@
 use std::{
-    fs::File,
     path::Path,
+    process::Command,
 };
 
-use failure::Error;
-
-fn main() -> Result<(), Error> {
+fn main() {
     println!("cargo:rerun-if-changed=data");
 
     let bios_path = Path::new("data/DMG_BIOS_ROM.bin");
 
-    if !bios_path.exists() {
-        reqwest::get("http://www.neviksti.com/DMG/DMG_ROM.bin")?
-            .copy_to(&mut File::create(bios_path)?)?;
-    }
 
-    Ok(())
+    if !bios_path.exists() {
+        Command::new("curl")
+            .arg("http://www.neviksti.com/DMG/DMG_ROM.bin")
+            .arg("--output")
+            .arg(bios_path)
+            .arg("--silent")
+            .status()
+            .expect("failed to execute curl");
+    }
 }


### PR DESCRIPTION
This makes Travis-CI builds faster. Hopefully. I changed three things:

- The `core/` build script doesn't use `reqwest` anymore and instead just calls `curl` (it assumes it's installed). This means we don't have to build all of `reqwest`'s dependencies (which are a lot).
- All stuff related to `mahboi-web` was put into a new build-thingy, which is allowed to fail. Once we start working on WASM, we can disallow failures again.
- I switched from travis-ci-com to travis-ci.org because the latter doesn't suffer from minute long container setup-times right now.