### PR TITLE
PPU: draw background layer + cleanup

### DIFF
--- a/core/src/instr.rs
+++ b/core/src/instr.rs
@@ -336,7 +336,7 @@ pub const INSTRUCTIONS: InstrDb<Option<Instr>> = InstrDb([
 
     Instr::some(0xe0, "LDH (a8), A",  2,  12, None),
     Instr::some(0xe1, "POP HL",       1,  12, None),
-    Instr::some(0xe2, "LD (C), A",    2,  8,  None),
+    Instr::some(0xe2, "LD (C), A",    1,  8,  None),
     None,
     None,
     Instr::some(0xe5, "PUSH HL",      1,  16, None),
@@ -353,7 +353,7 @@ pub const INSTRUCTIONS: InstrDb<Option<Instr>> = InstrDb([
 
     Instr::some(0xf0, "LDH A, (a8)",  2,  12, None),
     Instr::some(0xf1, "POP AF",       1,  12, None),
-    Instr::some(0xf2, "LD A, (C)",    2,  8,  None),
+    Instr::some(0xf2, "LD A, (C)",    1,  8,  None),
     Instr::some(0xf3, "DI",           1,  4,  None),
     None,
     Instr::some(0xf5, "PUSH AF",      1,  16, None),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -78,7 +78,6 @@ impl Emulator {
         }
 
         Ok(())
-        // Err(Disruption::Paused)
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -68,7 +68,7 @@ impl Emulator {
                 self.machine.ppu.step(peripherals.display());
             }
             if let Some(vector) = self.machine.ppu.should_interrupt() {
-                // debug!("Interrupt at {}", vector);
+                debug!("Interrupt at {}", vector);
             }
 
             self.machine.cycle_counter += cycles_spent;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -68,7 +68,7 @@ impl Emulator {
                 self.machine.ppu.step(peripherals.display());
             }
             if let Some(vector) = self.machine.ppu.should_interrupt() {
-                debug!("Interrupt at {}", vector);
+                // debug!("Interrupt at {}", vector);
             }
 
             self.machine.cycle_counter += cycles_spent;
@@ -78,6 +78,7 @@ impl Emulator {
         }
 
         Ok(())
+        // Err(Disruption::Paused)
     }
 }
 

--- a/core/src/machine/ppu.rs
+++ b/core/src/machine/ppu.rs
@@ -16,7 +16,7 @@ pub(crate) struct Ppu {
 
 
 
-    // ===== State of the pixel FIFO ======
+    // ===== State of the pixel transfer operation ======
     fifo: PixelFifo,
 
     /// Stores whether or not an fetch operation has already been started. This
@@ -366,21 +366,21 @@ impl Ppu {
 /// Breakdown of one frame:
 ///
 /// ```ignore
-///   ___|-- 20 cycles --|------- 43+ cycles -------|----------- 51- cycles -----------|
-///    |                 |                          |                                  |
-///    |                 |                             |                               |
-///    |                 |                           |                                 |
-///  144       OAM       |         Pixel                 |         H-Blank             |
-/// lines     Search     |        Transfer          |                                  |
-///    |                 |                            |                                |
-///    |                 |                             |                               |
-///    |                 |                          |                                  |
-///   -+-----------------+--------------------------+----------------------------------+
-///    |                                                                               |
-///   10                                  V-Blank                                      |
-/// lines                                                                              |
-///    |                                                                               |
-///    +-------------------------------------------------------------------------------+
+///    ┌── 20 cycles ──┬─────── 43+ cycles ───────┬─────────── 51- cycles ───────────┐
+///    │               │                          |                                  │
+///    │               │                             │                               │
+///    │               │                           │                                 │
+///  144      OAM      │         Pixel                 │         H-Blank             │
+/// lines    Search    │        Transfer          │                                  │
+///    │               │                            │                                │
+///    │               │                             │                               │
+///    │               │                          │                                  │
+///    ├───────────────┴──────────────────────────┴──────────────────────────────────┤
+///    │                                                                             │
+///   10                                V-Blank                                      │
+/// lines                                                                            │
+///    │                                                                             │
+///    └─────────────────────────────────────────────────────────────────────────────┘
 /// ```
 ///
 /// All cycles are machine-cycles (1 Mhz = 1_048_576). Pixel transfer can vary

--- a/core/src/machine/ppu.rs
+++ b/core/src/machine/ppu.rs
@@ -1,6 +1,7 @@
 use crate::{
     env::Display,
-    primitives::{Byte, Word, Memory},
+    log::*,
+    primitives::{Byte, Word, Memory, PixelPos, PixelColor},
 };
 
 
@@ -11,6 +12,20 @@ pub(crate) struct Ppu {
 
     /// How many cycles did we already spent in this line?
     cycle_in_line: u8,
+
+
+
+    // ===== State of the pixel FIFO ======
+    fifo: PixelFifo,
+
+    /// Stores whether or not an fetch operation has already been started. This
+    /// boolean usually flips every cycle during pixel transfer.
+    fetch_started: bool,
+
+    fetch_offset: u8,
+
+    /// ...
+    current_column: u8,
 
     // ===== Registers ======
     /// FF40: LCDC
@@ -56,6 +71,11 @@ impl Ppu {
             oam: Memory::zeroed(Word::new(0xA0)),
 
             cycle_in_line: 0,
+
+            fifo: PixelFifo::new(),
+            fetch_started: false,
+            fetch_offset: 0,
+            current_column: 0,
 
             lcd_control: Byte::zero(),
             status: Byte::zero(),
@@ -138,8 +158,14 @@ impl Ppu {
                 let v = self.status.get() & 0b0000_0111 | byte.get() & 0b0111_1000;
                 self.status = Byte::new(v);
             },
-            0xFF42 => self.scroll_y = byte,
-            0xFF43 => self.scroll_x = byte,
+            0xFF42 => {
+                debug!("[ppu] scroll_y set to {}", byte);
+                self.scroll_y = byte;
+            }
+            0xFF43 => {
+                debug!("[ppu] scroll_y set to {}", byte);
+                self.scroll_x = byte;
+            }
             0xFF44 => {}, // read only
             0xFF45 => self.lyc = byte,
             0xFF46 => {}, // TODO
@@ -188,35 +214,171 @@ impl Ppu {
     }
 
     /// Executes one machine cycle (1 Mhz).
-    pub(crate) fn step(&mut self, _display: &mut impl Display) {
+    pub(crate) fn step(&mut self, display: &mut impl Display) {
+        // Check if we're currently in V-Blank or ont.
+        if self.current_line.get() >= 144 {
+            // ===== V-Blank =====
+            if self.current_line == 144 && self.cycle_in_line == 0 {
+                self.set_phase(Phase::VBlank);
+                // TODO: trigger interrupt
+            }
+        } else {
+            // ===== Not in V-Blank =====
+            match (self.cycle_in_line, self.current_column) {
+                (0..20, 0) => {
+                    // TODO: OAM Search
+                }
+                (20..144, col) if col < 160 => {
+                    self.fifo_step(display);
+                }
+                (43..144, _) => {
+                    // TODO: H-Blank
+                    // debug!("[ppu] hblank. current_line: {}", self.current_line);
+                }
+                (cycles, col) => {
+                    // This state should never occur
+                    panic!("internal PPU error: cycle {} of line and col {}", cycles, col);
+                }
+            }
+        }
+
+        // match (self.current_line.get(), self.cycle_in_line) {
+        //     // New line, we start OAM search
+        //     (0..144, 0..20) => {
+        //         // TODO: OAM Search
+        //         self.set_phase(Phase::OamSearch);
+        //     }
+
+        //     // End of OAM search
+        //     (0..144, 20..) => {
+        //         self.set_phase(Phase::PixelTransfer);
+        //     }
+
+        //     // TODO: hblank
+        //     // // End of pixel transfer. TODO: this is not fixed!
+        //     // (0..144, 63) => self.set_phase(Phase::HBlank),
+
+        //     // Drawn all lines, starting vblank
+        //     (144, 0) => {
+        //         self.set_phase(Phase::VBlank);
+        //         // TODO: Trigger interrupt
+        //     }
+
+        //     _ => {}
+        // }
+
         // Update state/phase
         self.cycle_in_line += 1;
         if self.cycle_in_line == 114 {
             self.current_line += 1;
             self.cycle_in_line = 0;
+            self.current_column = 0;
+            self.fetch_offset = 0;
+            self.fifo.clear();
+            // debug!("NEW LINE {} ---------------------------------------------", self.current_line);
 
             if self.current_line == 154 {
                 self.current_line = Byte::new(0);
             }
         }
 
-        match (self.current_line.get(), self.cycle_in_line) {
-            // New line
-            (line, 0) if line < 144 => self.set_phase(Phase::OamSearch),
 
-            // End of OAM search
-            (line, 20) if line < 144 => self.set_phase(Phase::PixelTransfer),
+    }
 
-            // End of pixel transfer. TODO: this is not fixed!
-            (line, 63) if line < 144 => self.set_phase(Phase::HBlank),
-
-            // Drawn all lines, starting vblank
-            (144, 0) => self.set_phase(Phase::VBlank),
-
-            _ => {}
+    fn fifo_step(&mut self, display: &mut impl Display) {
+        // Push out up to four new pixels if we have enough data in the FIFO.
+        let mut pixel_pushed = 0;
+        while self.fifo.len() > 8 && pixel_pushed < 4 {
+            self.push_pixel(display);
+            pixel_pushed += 1;
         }
 
-        // TODO
+        // Fetch new data. We need two steps to perform once fetch. We just
+        // don't do anything the first time `step()` except for setting
+        // `fetch_start = true`. The actual work is done in the second step.
+        if !self.fetch_started {
+            self.fetch_started = true;
+        } else {
+            let pos_x = (self.scroll_x + self.fetch_offset).get();
+            let pos_y = (self.scroll_y + self.current_line).get();
+
+            let tile_x = pos_x / 8;
+            let tile_y = pos_y / 8;
+
+            // Background map data is stored in: 0x9800 - 0x9BFF
+            let background_addr = Word::new(0x9800 + tile_y as u16 * 32 + tile_x as u16);
+            let tile_id = self.load_vram_byte(background_addr);
+
+            // We calculate the start address of the tile we want to load from.
+            // Each tile uses 16 bytes.
+            let tile_start = Word::new(0x8000 + tile_id.get() as u16 * 16);
+
+            // We only need to load one line (two bytes), so we need to
+            // calculate that offset.
+            let line_offset = tile_start + 2 * (pos_y % 8);
+            let byte0 = self.load_vram_byte(line_offset).get();
+            let byte1 = self.load_vram_byte(line_offset + 1u8).get();
+
+            // The color number of each pixel is split between the bytes:
+            // `byte0` defines the lower bit of the color number, while `byte1`
+            // defines the upper bit.
+            let new_pixels = [
+                (ColorPattern::from_byte(((byte0 >> 7) & 0b1) | (((byte1 >> 7) & 0b1) << 1)), PixelSource::Background),
+                (ColorPattern::from_byte(((byte0 >> 6) & 0b1) | (((byte1 >> 6) & 0b1) << 1)), PixelSource::Background),
+                (ColorPattern::from_byte(((byte0 >> 5) & 0b1) | (((byte1 >> 5) & 0b1) << 1)), PixelSource::Background),
+                (ColorPattern::from_byte(((byte0 >> 4) & 0b1) | (((byte1 >> 4) & 0b1) << 1)), PixelSource::Background),
+                (ColorPattern::from_byte(((byte0 >> 3) & 0b1) | (((byte1 >> 3) & 0b1) << 1)), PixelSource::Background),
+                (ColorPattern::from_byte(((byte0 >> 2) & 0b1) | (((byte1 >> 2) & 0b1) << 1)), PixelSource::Background),
+                (ColorPattern::from_byte(((byte0 >> 1) & 0b1) | (((byte1 >> 1) & 0b1) << 1)), PixelSource::Background),
+                (ColorPattern::from_byte(((byte0 >> 0) & 0b1) | (((byte1 >> 0) & 0b1) << 1)), PixelSource::Background),
+            ];
+            // [(ColorPattern, PixelSource); 8]
+            self.fifo.add_data(new_pixels);
+            // if self.current_line == 0 {
+            //     debug!(
+            //         "[ppu] fetched 8 pixels. current_col: {} ,pos_x: {}, pos_y: {}, scroll_x: {}, scroll_y: {}, tile_x: {}, tile_y: {}\
+            //             , bg_addr: {}, tile_id: {}, tile_start: {}, line_offset: {}, new FIFO len: {}",
+            //         self.current_column,
+            //         pos_x,
+            //         pos_y,
+            //         self.scroll_x,
+            //         self.scroll_y,
+            //         tile_x,
+            //         tile_y,
+            //         background_addr,
+            //         tile_id,
+            //         tile_start,
+            //         line_offset,
+            //         self.fifo.len()
+            //     );
+            // }
+
+            // Reset status flag
+            self.fetch_started = false;
+            self.fetch_offset += 8;
+        }
+    }
+
+    fn push_pixel(&mut self, display: &mut impl Display) {
+        fn pattern_to_color(pattern: ColorPattern, palette: Byte) -> PixelColor {
+            let color = (palette.get() >> (pattern.as_byte() * 2)) & 0b11;
+
+            PixelColor::from_greyscale(color)
+        }
+
+        let (pattern, source) = self.fifo.emit();
+        let color = match source {
+            PixelSource::Background => pattern_to_color(pattern, self.background_palette),
+            PixelSource::Sprite0 => pattern_to_color(pattern, self.sprite_palette_0),
+            PixelSource::Sprite1 => pattern_to_color(pattern, self.sprite_palette_1),
+        };
+
+        let pos = PixelPos::new(self.current_column, self.current_line.get());
+        display.set_pixel(pos, color);
+        self.current_column += 1;
+        // if pattern != ColorPattern::Pat00 {
+        //     debug!("[ppu] pushed pixel {:?} to pattern {:?}", pos, pattern);
+        // }
     }
 }
 
@@ -225,7 +387,7 @@ impl Ppu {
 /// Breakdown of one frame:
 ///
 /// ```ignore
-///   ___|-- 20 clocks --|------- 43+ clocks -------|----------- 51- clocks -----------|
+///   ___|-- 20 cycles --|------- 43+ cycles -------|----------- 51- cycles -----------|
 ///    |                 |                          |                                  |
 ///    |                 |                             |                               |
 ///    |                 |                           |                                 |
@@ -265,4 +427,93 @@ pub enum Phase {
     /// Also called "Mode 1": Time after the last line has been drawn and
     /// before the next frame begins.
     VBlank,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum ColorPattern {
+    Pat00,
+    Pat01,
+    Pat10,
+    Pat11,
+}
+
+impl ColorPattern {
+    fn from_byte(b: u8) -> Self {
+        match b {
+            0 => ColorPattern::Pat00,
+            1 => ColorPattern::Pat01,
+            2 => ColorPattern::Pat10,
+            3 => ColorPattern::Pat11,
+            _ => panic!("called `ColorPattern::from_byte` with byte > 3"),
+        }
+    }
+
+    fn as_byte(&self) -> u8 {
+        match self {
+            ColorPattern::Pat00 => 0,
+            ColorPattern::Pat01 => 1,
+            ColorPattern::Pat10 => 2,
+            ColorPattern::Pat11 => 3,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum PixelSource {
+    /// Pixel with background palette
+    Background,
+
+    /// Sprite with palette 0
+    Sprite0,
+
+    /// Sprite with palette 1
+    Sprite1,
+}
+
+struct PixelFifo {
+    data: [(ColorPattern, PixelSource); 16],
+    start: usize,
+    len: usize,
+}
+
+impl PixelFifo {
+    fn new() -> Self {
+        Self {
+            // Dummy data
+            data: [(ColorPattern::Pat00, PixelSource::Background); 16],
+            start: 0,
+            len: 0,
+        }
+    }
+
+    fn len(&self) -> u8 {
+        self.len as u8
+    }
+
+    fn clear(&mut self) {
+        self.start = 0;
+        self.len = 0;
+    }
+
+    fn emit(&mut self) -> (ColorPattern, PixelSource) {
+        assert!(self.len() > 0, "Called emit() on empty pixel FIFO");
+
+        let out = self.data[self.start];
+        self.len -= 1;
+        self.start += 1;
+        if self.start == self.data.len() {
+            self.start = 0;
+        }
+
+        out
+    }
+
+    fn add_data(&mut self, data: [(ColorPattern, PixelSource); 8]) {
+        assert!(self.len() <= 8, "called `add_data` for pixel FIFO with more than 8 pixels");
+
+        for (i, &elem) in data.iter().enumerate() {
+            self.data[(self.start + self.len + i) % 16] = elem;
+        }
+        self.len += 8;
+    }
 }

--- a/core/src/machine/ppu.rs
+++ b/core/src/machine/ppu.rs
@@ -304,8 +304,9 @@ impl Ppu {
 
             // if self.current_line == 0 {
             //     debug!(
-            //         "[ppu] fetched 8 pixels. current_col: {} ,pos_x: {}, pos_y: {}, scroll_x: {}, scroll_y: {}, tile_x: {}, tile_y: {}\
-            //             , bg_addr: {}, tile_id: {}, tile_start: {}, line_offset: {}, new FIFO len: {}",
+            //         "[ppu] fetched 8 pixels. current_col: {} ,pos_x: {}, pos_y: {}, \
+            //             scroll_x: {}, scroll_y: {}, tile_x: {}, tile_y: {}, bg_addr: {}, \
+            //             tile_id: {}, tile_start: {}, line_offset: {}, new FIFO len: {}",
             //         self.current_column,
             //         pos_x,
             //         pos_y,

--- a/core/src/primitives.rs
+++ b/core/src/primitives.rs
@@ -409,6 +409,7 @@ mod test {
 }
 
 /// Position of a pixel on a gameboy screen.
+#[derive(Clone, Copy, Debug)]
 pub struct PixelPos {
     x: u8,
     y: u8,
@@ -438,6 +439,7 @@ impl PixelPos {
 /// Each channel has a depth of 5 bit = 32 different values, so `r`, `g` and
 /// `b` hold values between 0 and 31 (inclusive). In sum, this means we have
 /// 32^3 = 32768 different colors.
+#[derive(Clone, Copy, Debug)]
 pub struct PixelColor {
     r: u8,
     g: u8,
@@ -462,7 +464,8 @@ impl PixelColor {
     /// Creates a color from a classic gameboy color (2 bit). The given `c`
     /// value has to be 0, 1, 2 or 3.
     pub fn from_greyscale(c: u8) -> Self {
-        let v = c << 3;
+        assert!(c <= 3);
+        let v = (3 - c) << 3;
         Self {
             r: v,
             g: v,

--- a/core/src/primitives.rs
+++ b/core/src/primitives.rs
@@ -459,6 +459,17 @@ impl PixelColor {
         }
     }
 
+    /// Creates a color from a classic gameboy color (2 bit). The given `c`
+    /// value has to be 0, 1, 2 or 3.
+    pub fn from_greyscale(c: u8) -> Self {
+        let v = c << 3;
+        Self {
+            r: v,
+            g: v,
+            b: v,
+        }
+    }
+
     /// Creates a new `PixelColor` instance. `r`, `g` and `b` have to be
     /// smaller than 32!
     pub fn new(r: u8, g: u8, b: u8) -> Self {


### PR DESCRIPTION
This contains a bunch of cleanup and rewrites of PPU stuff. However, it's still far from done. There are still quite a few variables and fields that might be removed in the future. The code contains a bunch of disabled logging statements, too. Those will be removed once the dust around the PPU settles.

What this PR contains:
- A more or less finished version of the `PixelFifo` (I actually think this can stay pretty much like this)
- The PPU correctly (I think?) draws the background. I also think that the timing is more or less correct (4 pixels per cycles, ...)
- Completely unrelated to the PPU: a bug fix in the instruction data