### PR TITLE
PPU background addressing fixes and almost all remaining instructions

### DIFF
--- a/core/src/machine/mod.rs
+++ b/core/src/machine/mod.rs
@@ -246,7 +246,7 @@ impl Cpu {
         (self.f.get() & 0b1000_0000) != 0
     }
 
-    pub fn substract(&self) -> bool {
+    pub fn subtract(&self) -> bool {
         (self.f.get() & 0b0100_0000) != 0
     }
 

--- a/core/src/machine/mod.rs
+++ b/core/src/machine/mod.rs
@@ -257,4 +257,149 @@ impl Cpu {
     pub fn carry(&self) -> bool {
         (self.f.get() & 0b0001_0000) != 0
     }
+
+    /// The DAA instruction adjusts the contents of the accumulator
+    /// depending on which arithmetic instruction was executed
+    /// before. If SUB or SBC was executed before, the `subtract`
+    /// flag is set to 1, and if ADD or ADC was used, it is set to
+    /// 0.
+    ///
+    /// This instruction assumes that both operands of the previous
+    /// operation were already in BCD form.
+    ///
+    /// This implementation is based on information from these
+    /// sources:
+    /// - https://forums.nesdev.com/viewtopic.php?f=20&t=15944
+    /// - https://ehaskins.com/2018-01-30%20Z80%20DAA/
+    pub(crate) fn daa(&mut self) -> bool {
+        // The carry flag is only set in one specific case.
+        let mut carry = false;
+
+        if self.subtract() {
+            // Subtraction: we will subtract 0, 6, 0x60 or 0x66 from
+            // the accumulator. We can determine this for each digit
+            // seperately.
+            if self.carry() {
+                self.a -= 0x60;
+            }
+
+            if self.half_carry() {
+                self.a -= 0x6;
+            }
+        } else {
+            // Addition: we will add 0, 6, 0x60 or 0x66 to the
+            // accumulator. We can determine this for each digit
+            // seperately.
+            let a_lo = self.a.get() & 0x0F;
+            let a_hi = self.a.get() >> 4;
+
+            if self.half_carry() || a_lo > 0x9 {
+                self.a += 0x6;
+            }
+
+            if self.carry() || a_hi > 0x9 {
+                self.a += 0x60;
+                carry = true;
+            }
+        }
+
+        carry
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+
+    #[test]
+    fn test_cpu_daa() {
+        fn run(sub: bool, cy: bool, h: bool, a: u8) -> (i8, bool) {
+            let mut cpu = Cpu::new();
+            cpu.a = Byte::new(a);
+            set_flags!(cpu.f => 0 sub h cy);
+            let carry = cpu.daa();
+            ((cpu.a.get().wrapping_sub(a)) as i8, carry)
+        }
+
+        // ========== ADD ==========
+        // CY: 0, high nybble: 0-9, H: 0, low nybble: 0-9, added: 0x00, CY result: 0
+        assert_eq!(run(false, false, false, 0x00), (0x00, false));
+        assert_eq!(run(false, false, false, 0x09), (0x00, false));
+        assert_eq!(run(false, false, false, 0x90), (0x00, false));
+        assert_eq!(run(false, false, false, 0x99), (0x00, false));
+
+        // CY: 0, high nybble: 0-8, H: 0, low nybble: A-F, added: 0x06, CY result: 0
+        assert_eq!(run(false, false, false, 0x0A), (0x06, false));
+        assert_eq!(run(false, false, false, 0x0F), (0x06, false));
+        assert_eq!(run(false, false, false, 0x8A), (0x06, false));
+        assert_eq!(run(false, false, false, 0x8F), (0x06, false));
+
+        // CY: 0, high nybble: 0-9, H: 1, low nybble: 0-3, added: 0x06, CY result: 0
+        assert_eq!(run(false, false, true, 0x00), (0x06, false));
+        assert_eq!(run(false, false, true, 0x03), (0x06, false));
+        assert_eq!(run(false, false, true, 0x90), (0x06, false));
+        assert_eq!(run(false, false, true, 0x93), (0x06, false));
+
+        // CY: 0, high nybble: A-F, H: 0, low nybble: 0-9, added: 0x60, CY result: 1
+        assert_eq!(run(false, false, false, 0xA0), (0x60, true));
+        assert_eq!(run(false, false, false, 0xA9), (0x60, true));
+        assert_eq!(run(false, false, false, 0xF0), (0x60, true));
+        assert_eq!(run(false, false, false, 0xF9), (0x60, true));
+
+        // CY: 0, high nybble: 9-F, H: 0, low nybble: A-F, added: 0x66, CY result: 1
+        assert_eq!(run(false, false, false, 0x9A), (0x66, true));
+        assert_eq!(run(false, false, false, 0x9F), (0x66, true));
+        assert_eq!(run(false, false, false, 0xFF), (0x66, true));
+        assert_eq!(run(false, false, false, 0xFF), (0x66, true));
+
+        // CY: 0, high nybble: A-F, H: 1, low nybble: 0-3, added: 0x66, CY result: 1
+        assert_eq!(run(false, false, true, 0xA0), (0x66, true));
+        assert_eq!(run(false, false, true, 0xA3), (0x66, true));
+        assert_eq!(run(false, false, true, 0xF0), (0x66, true));
+        assert_eq!(run(false, false, true, 0xF3), (0x66, true));
+
+        // CY: 1, high nybble: 0-2, H: 0, low nybble: 0-9, added: 0x60, CY result: 1
+        assert_eq!(run(false, true, false, 0x00), (0x60, true));
+        assert_eq!(run(false, true, false, 0x09), (0x60, true));
+        assert_eq!(run(false, true, false, 0x20), (0x60, true));
+        assert_eq!(run(false, true, false, 0x29), (0x60, true));
+
+        // CY: 1, high nybble: 0-2, H: 0, low nybble: A-F, added: 0x66, CY result: 1
+        assert_eq!(run(false, true, false, 0x0A), (0x66, true));
+        assert_eq!(run(false, true, false, 0x0F), (0x66, true));
+        assert_eq!(run(false, true, false, 0x2A), (0x66, true));
+        assert_eq!(run(false, true, false, 0x2F), (0x66, true));
+
+        // CY: 1, high nybble: 0-3, H: 1, low nybble: 0-3, added: 0x66, CY result: 1
+        assert_eq!(run(false, true, true, 0x00), (0x66, true));
+        assert_eq!(run(false, true, true, 0x03), (0x66, true));
+        assert_eq!(run(false, true, true, 0x30), (0x66, true));
+        assert_eq!(run(false, true, true, 0x33), (0x66, true));
+
+        // ========== SUB ==========
+        // CY: 0, high nybble: 0-9, H: 0, low nybble: 0-9, added: 0x00, CY result: 0
+        assert_eq!(run(true, false, false, 0x00), (0x00, false));
+        assert_eq!(run(true, false, false, 0x09), (0x00, false));
+        assert_eq!(run(true, false, false, 0x90), (0x00, false));
+        assert_eq!(run(true, false, false, 0x99), (0x00, false));
+
+        // CY: 0, high nybble: 0-8, H: 1, low nybble: 6-F, added: -0x06, CY result: 0
+        assert_eq!(run(true, false, true, 0x06), (-0x06, false));
+        assert_eq!(run(true, false, true, 0x0F), (-0x06, false));
+        assert_eq!(run(true, false, true, 0x86), (-0x06, false));
+        assert_eq!(run(true, false, true, 0x8F), (-0x06, false));
+
+        // CY: 1, high nybble: 7-F, H: 0, low nybble: 0-9, added: -0x60, CY result: 1
+        assert_eq!(run(true, true, false, 0x70), (-0x60, true));
+        assert_eq!(run(true, true, false, 0x79), (-0x60, true));
+        assert_eq!(run(true, true, false, 0xF0), (-0x60, true));
+        assert_eq!(run(true, true, false, 0xF9), (-0x60, true));
+
+        // CY: 1, high nybble: 6-F, H: 1, low nybble: 6-F, added: -0x66, CY result: 1
+        assert_eq!(run(true, true, true, 0x66), (-0x66, true));
+        assert_eq!(run(true, true, true, 0x6F), (-0x66, true));
+        assert_eq!(run(true, true, true, 0xF6), (-0x66, true));
+        assert_eq!(run(true, true, true, 0xFF), (-0x66, true));
+    }
 }

--- a/core/src/machine/mod.rs
+++ b/core/src/machine/mod.rs
@@ -281,6 +281,7 @@ impl Cpu {
             // seperately.
             if self.carry() {
                 self.a -= 0x60;
+                carry = true;
             }
 
             if self.half_carry() {
@@ -297,7 +298,7 @@ impl Cpu {
                 self.a += 0x6;
             }
 
-            if self.carry() || a_hi > 0x9 {
+            if self.carry() || (a_hi > 0x9 && a_lo < 0xA) || (a_hi > 0x8 && a_lo > 0x9) {
                 self.a += 0x60;
                 carry = true;
             }

--- a/core/src/machine/step.rs
+++ b/core/src/machine/step.rs
@@ -716,11 +716,25 @@ impl Machine {
                 self.interrupt_controller.ime = true;
             }
 
-            // ========== miscellaneous ==========
+            // ========== Non-prefix rotate instructions ==========
             opcode!("RLA") => {
                 let carry = self.cpu.a.rotate_left_through_carry(self.cpu.carry());
                 set_flags!(self.cpu.f => 0 0 0 carry);
             }
+            opcode!("RRA") => {
+                let carry = self.cpu.a.rotate_right_through_carry(self.cpu.carry());
+                set_flags!(self.cpu.f => 0 0 0 carry);
+            }
+            opcode!("RLCA") => {
+                let carry = self.cpu.a.rotate_left();
+                set_flags!(self.cpu.f => 0 0 0 carry);
+            }
+            opcode!("RRCA") => {
+                let carry = self.cpu.a.rotate_right();
+                set_flags!(self.cpu.f => 0 0 0 carry);
+            }
+
+            // ========== miscellaneous ==========
             opcode!("DI") => self.interrupt_controller.ime = false,
             opcode!("EI") => self.enable_interrupts_next_step = true,
             opcode!("HALT") => self.halt = true,

--- a/core/src/machine/step.rs
+++ b/core/src/machine/step.rs
@@ -641,8 +641,42 @@ impl Machine {
             opcode!("PUSH HL") => self.push(self.cpu.hl()),
             opcode!("PUSH AF") => self.push(self.cpu.af()),
 
-            // ========== CALL/RET ==========
+            // ========== CALL ==========
             opcode!("CALL a16") => call!(arg_word),
+            opcode!("CALL NZ, a16") => {
+                if !self.cpu.zero() {
+                    call!(arg_word);
+                    action_taken = Some(true);
+                } else {
+                    action_taken = Some(false);
+                }
+            }
+            opcode!("CALL Z, a16") => {
+                if self.cpu.zero() {
+                    call!(arg_word);
+                    action_taken = Some(true);
+                } else {
+                    action_taken = Some(false);
+                }
+            }
+            opcode!("CALL NC, a16") => {
+                if !self.cpu.carry() {
+                    call!(arg_word);
+                    action_taken = Some(true);
+                } else {
+                    action_taken = Some(false);
+                }
+            }
+            opcode!("CALL C, a16") => {
+                if self.cpu.carry() {
+                    call!(arg_word);
+                    action_taken = Some(true);
+                } else {
+                    action_taken = Some(false);
+                }
+            }
+
+            // ========== RET ==========
             opcode!("RET") => ret!(),
             opcode!("RET NZ") => {
                 if !self.cpu.zero() {

--- a/core/src/machine/step.rs
+++ b/core/src/machine/step.rs
@@ -369,7 +369,9 @@ impl Machine {
             opcode!("LD SP, d16") => self.cpu.sp = arg_word,
             opcode!("LD SP, HL") => self.cpu.sp = self.cpu.hl(),
             opcode!("LD HL, SP+r8") => {
-                let src = self.cpu.sp + arg_byte.get() as i8;
+                let mut src = self.cpu.sp;
+                let (carry, half_carry) = src.add_i8_with_carries(arg_byte.get() as i8);
+                set_flags!(self.cpu.f => 0 0 half_carry carry);
                 self.cpu.set_hl(self.load_word(src));
             }
             opcode!("LD (a16), SP") => self.store_word(arg_word, self.cpu.sp),
@@ -471,7 +473,8 @@ impl Machine {
             opcode!("ADD HL, SP") => add_hl!(self.cpu.sp),
 
             opcode!("ADD SP, r8") => {
-                self.cpu.sp += arg_byte.get() as i8;
+                let (carry, half_carry) = self.cpu.sp.add_i8_with_carries(arg_byte.get() as i8);
+                set_flags!(self.cpu.f => 0 0 half_carry carry);
             }
 
             // ========== ADC ==========

--- a/core/src/machine/step.rs
+++ b/core/src/machine/step.rs
@@ -759,51 +759,7 @@ impl Machine {
                 set_flags!(self.cpu.f => - 0 0 carry);
             }
             opcode!("DAA") => {
-                // The DAA instruction adjusts the contents of the accumulator
-                // depending on which arithmetic instruction was executed
-                // before. If SUB or SBC was executed before, the `subtract`
-                // flag is set to 1, and if ADD or ADC was used, it is set to
-                // 0.
-                //
-                // This instruction assumes that both operands of the previous
-                // operation were already in BCD form.
-                //
-                // This implementation is based on information from these
-                // sources:
-                // - https://forums.nesdev.com/viewtopic.php?f=20&t=15944
-                // - https://ehaskins.com/2018-01-30%20Z80%20DAA/
-
-                // The carry flag is only set in one specific case.
-                let mut carry = false;
-
-                if self.cpu.subtract() {
-                    // Subtraction: we will subtract 0, 6, 0x60 or 0x66 from
-                    // the accumulator. We can determine this for each digit
-                    // seperately.
-                    if self.cpu.carry() {
-                        self.cpu.a -= 0x60;
-                    }
-
-                    if self.cpu.half_carry() {
-                        self.cpu.a -= 0x6;
-                    }
-                } else {
-                    // Addition: we will add 0, 6, 0x60 or 0x66 to the
-                    // accumulator. We can determine this for each digit
-                    // seperately.
-                    let a_lo = self.cpu.a.get() & 0x0F;
-                    let a_hi = self.cpu.a.get() >> 4;
-
-                    if self.cpu.half_carry() || a_lo > 0x9 {
-                        self.cpu.a += 0x6;
-                    }
-
-                    if self.cpu.carry() || a_hi > 0x9 {
-                        self.cpu.a += 0x60;
-                        carry = true;
-                    }
-                }
-
+                let carry = self.cpu.daa();
                 let zero = self.cpu.a == 0;
                 set_flags!(self.cpu.f => zero - 0 carry);
             }

--- a/core/src/machine/step.rs
+++ b/core/src/machine/step.rs
@@ -566,6 +566,22 @@ impl Machine {
                     action_taken = Some(false);
                 }
             }
+            opcode!("JR NC, r8") => {
+                if !self.cpu.carry() {
+                    self.cpu.pc += arg_byte.get() as i8;
+                    action_taken = Some(true);
+                } else {
+                    action_taken = Some(false);
+                }
+            }
+            opcode!("JR C, r8") => {
+                if self.cpu.carry() {
+                    self.cpu.pc += arg_byte.get() as i8;
+                    action_taken = Some(true);
+                } else {
+                    action_taken = Some(false);
+                }
+            }
 
             // ========== JP ==========
             opcode!("JP a16") => self.cpu.pc = arg_word,

--- a/core/src/machine/step.rs
+++ b/core/src/machine/step.rs
@@ -735,6 +735,13 @@ impl Machine {
             }
 
             // ========== miscellaneous ==========
+            opcode!("SCF") => {
+                set_flags!(self.cpu.f => - 0 0 1);
+            }
+            opcode!("CCF") => {
+                let carry = !self.cpu.carry();
+                set_flags!(self.cpu.f => - 0 0 carry);
+            }
             opcode!("DI") => self.interrupt_controller.ime = false,
             opcode!("EI") => self.enable_interrupts_next_step = true,
             opcode!("HALT") => self.halt = true,

--- a/core/src/machine/step.rs
+++ b/core/src/machine/step.rs
@@ -367,10 +367,19 @@ impl Machine {
             opcode!("LD DE, d16") => self.cpu.set_de(arg_word),
             opcode!("LD HL, d16") => self.cpu.set_hl(arg_word),
             opcode!("LD SP, d16") => self.cpu.sp = arg_word,
+            opcode!("LD SP, HL") => self.cpu.sp = self.cpu.hl(),
+            opcode!("LD HL, SP+r8") => {
+                let src = self.cpu.sp + arg_byte.get() as i8;
+                self.cpu.set_hl(self.load_word(src));
+            }
+            opcode!("LD (a16), SP") => self.store_word(arg_word, self.cpu.sp),
 
             opcode!("LD (C), A") => {
                 let dst = Word::new(0xFF00) + self.cpu.c;
                 self.store_byte(dst, self.cpu.a);
+            }
+            opcode!("LD A, (C)") => {
+                self.cpu.a = self.load_byte(Word::new(0xFF00) + self.cpu.c);
             }
             opcode!("LDH (a8), A") => {
                 let dst = Word::new(0xFF00) + arg_byte;

--- a/core/src/machine/step.rs
+++ b/core/src/machine/step.rs
@@ -470,6 +470,10 @@ impl Machine {
             opcode!("ADD HL, HL") => add_hl!(self.cpu.hl()),
             opcode!("ADD HL, SP") => add_hl!(self.cpu.sp),
 
+            opcode!("ADD SP, r8") => {
+                self.cpu.sp += arg_byte.get() as i8;
+            }
+
             // ========== ADC ==========
             opcode!("ADC A, B")     => adc!(self.cpu.b),
             opcode!("ADC A, C")     => adc!(self.cpu.c),

--- a/core/src/primitives.rs
+++ b/core/src/primitives.rs
@@ -282,6 +282,27 @@ impl Word {
 
         (carry, half_carry)
     }
+
+    /// Adds the given `i8` to this [`Word`] and returns a tuple containing information
+    /// about carry and half carry bits: `(carry, half_carry)`.
+    pub fn add_i8_with_carries(&mut self, rhs: i8) -> (bool, bool) {
+        let half_carry;
+        let carry;
+
+        if rhs < 0 {
+            // RHS is negative. We make it positive (through `i16` to avoid
+            // -128 problem) and then check for the carries via `checked_sub`.
+            carry = self.get().checked_sub(-(rhs as i16) as u16).is_none();
+            half_carry = ((self.get() & 0xFF) as u8).checked_sub(-(rhs as i16) as u8).is_none();
+        } else {
+            // RHS is positive: we check for carries via `checked_add`.
+            carry = self.get().checked_add(rhs as u16).is_none();
+            half_carry = ((self.get() & 0xFF) as u8).checked_add(rhs as u8).is_none();
+        };
+        *self += rhs;
+
+        (carry, half_carry)
+    }
 }
 
 impl Add for Word {
@@ -524,6 +545,23 @@ mod test {
         assert_eq!(run(0xffff, 0x0001), (true,  true));
         assert_eq!(run(0x7fff, 0x0001), (false, true));
         assert_eq!(run(0x8000, 0x8000), (true,  false));
+    }
+
+    #[test]
+    fn test_word_plus_i8() {
+        fn run(lhs: u16, rhs: i8) -> (u16, bool, bool) {
+            let mut w = Word::new(lhs);
+            let (carry, half_carry) = w.add_i8_with_carries(rhs);
+            (w.get(), carry, half_carry)
+        }
+
+        assert_eq!(run(0x0000,      0), (0x0000, false, false));
+        assert_eq!(run(0x0000,      2), (0x0002, false, false));
+        assert_eq!(run(0x0000,     -2), (0xFFFE, true,  true));
+        assert_eq!(run(0x0002,     -2), (0x0000, false, false));
+        assert_eq!(run(0xFFFE,      3), (0x0001, true,  true));
+        assert_eq!(run(0xFFFE,     -3), (0xFFFB, false, false));
+        assert_eq!(run(0x01FF,   -128), (0x017F, false, false));
     }
 }
 

--- a/core/src/primitives.rs
+++ b/core/src/primitives.rs
@@ -562,6 +562,11 @@ mod test {
         assert_eq!(run(0xFFFE,      3), (0x0001, true,  true));
         assert_eq!(run(0xFFFE,     -3), (0xFFFB, false, false));
         assert_eq!(run(0x01FF,   -128), (0x017F, false, false));
+        assert_eq!(run(0x00FF,      1), (0x0100, false, true));
+        assert_eq!(run(0x0081,   0x7F), (0x0100, false, true));
+        assert_eq!(run(0x0081,  -0x80), (0x0001, false, false));
+        assert_eq!(run(0xFFFF,      1), (0x0000, true,  true));
+        assert_eq!(run(0x0000,     -1), (0xFFFF, true,  true));
     }
 }
 

--- a/desktop/src/debug/tui/mod.rs
+++ b/desktop/src/debug/tui/mod.rs
@@ -705,7 +705,7 @@ impl TuiDebugger {
         body.append_plain("Z: ");
         body.append_styled((cpu.zero() as u8).to_string(), reg_style);
         body.append_plain("  N: ");
-        body.append_styled((cpu.substract() as u8).to_string(), reg_style);
+        body.append_styled((cpu.subtract() as u8).to_string(), reg_style);
         body.append_plain("  H: ");
         body.append_styled((cpu.half_carry() as u8).to_string(), reg_style);
         body.append_plain("  C: ");


### PR DESCRIPTION
#nonatomicpr

The first two commits fix the addressing of background tile data and the background tile map in the PPU. The remaining commits implement new instructions. Now only ONE instruction is missing: `STOP`. :tada: 